### PR TITLE
[QA-877] Add component flag to jira create issue

### DIFF
--- a/cmd/jira.go
+++ b/cmd/jira.go
@@ -24,7 +24,7 @@ func init() {
 	jiraCreateIssueCmdF.StringP("type", "t", "", "issue type")
 	jiraCreateIssueCmdF.StringSliceP("labels", "l", []string{}, "issue labels")
 	jiraCreateIssueCmdF.StringToString("custom", map[string]string{}, "issue custom fields")
-	jiraCreateIssueCmdF.StringSlice("component", []string{}, "issue component (repeatable)")
+	jiraCreateIssueCmdF.StringSlice("components", []string{}, "issue components (repeatable)")
 }
 
 var jiraCmd = &cobra.Command{
@@ -78,7 +78,7 @@ var jiraCreateIssueCmd = &cobra.Command{
 		}
 		labels, _ := cmd.Flags().GetStringSlice("labels")
 		customFields, _ := cmd.Flags().GetStringToString("custom")
-		components, _ := cmd.Flags().GetStringSlice("component")
+		components, _ := cmd.Flags().GetStringSlice("components")
 
 		key, err := jira.CreateIssue(&jira.CreateIssueArgs{
 			Common:       commonArgs,

--- a/cmd/jira.go
+++ b/cmd/jira.go
@@ -24,6 +24,7 @@ func init() {
 	jiraCreateIssueCmdF.StringP("type", "t", "", "issue type")
 	jiraCreateIssueCmdF.StringSliceP("labels", "l", []string{}, "issue labels")
 	jiraCreateIssueCmdF.StringToString("custom", map[string]string{}, "issue custom fields")
+	jiraCreateIssueCmdF.StringSlice("component", []string{}, "issue component (repeatable)")
 }
 
 var jiraCmd = &cobra.Command{
@@ -77,6 +78,7 @@ var jiraCreateIssueCmd = &cobra.Command{
 		}
 		labels, _ := cmd.Flags().GetStringSlice("labels")
 		customFields, _ := cmd.Flags().GetStringToString("custom")
+		components, _ := cmd.Flags().GetStringSlice("component")
 
 		key, err := jira.CreateIssue(&jira.CreateIssueArgs{
 			Common:       commonArgs,
@@ -86,6 +88,7 @@ var jiraCreateIssueCmd = &cobra.Command{
 			Type:         issueType,
 			Labels:       labels,
 			CustomFields: customFields,
+			Components:   components,
 		})
 		if err != nil {
 			return err

--- a/jira/issue.go
+++ b/jira/issue.go
@@ -17,6 +17,7 @@ type CreateIssueArgs struct {
 	Type         string
 	Labels       []string
 	CustomFields map[string]string
+	Components   []string
 }
 
 func CreateIssue(args *CreateIssueArgs) (string, error) {
@@ -51,6 +52,19 @@ func CreateIssue(args *CreateIssueArgs) (string, error) {
 			Labels:      args.Labels,
 			Unknowns:    customFields,
 		},
+	}
+
+	if len(args.Components) > 0 {
+		components := make([]*gojira.Component, 0, len(args.Components))
+		for _, name := range args.Components {
+			if name == "" {
+				continue
+			}
+			components = append(components, &gojira.Component{Name: name})
+		}
+		if len(components) > 0 {
+			issue.Fields.Components = components
+		}
 	}
 
 	if args.Assignee != "" {


### PR DESCRIPTION
Add a --component flag that which will link components to a jira issue on creation if given

Implemented in these two PRs:

1. https://github.com/braincorp/actions/pull/14
2. https://github.com/braincorp/taros/pull/5227